### PR TITLE
fix(cert-file): error handling when cert file cannot be opened or deserialized

### DIFF
--- a/src/danebot.py
+++ b/src/danebot.py
@@ -161,10 +161,13 @@ class DaneBot:
             {args.rfc2136_tsig_key: args.rfc2136_tsig_secret}
         )
 
-        with open(args.cert_file, "rb") as cert_file:
-            cert_pem = cert_file.read()
-        self.cert = x509.load_pem_x509_certificate(cert_pem)
-        self.key = serialization.load_pem_private_key(cert_pem, password=None)
+        try:
+            with open(args.cert_file, "rb") as cert_file:
+                cert_pem = cert_file.read()
+            self.cert = x509.load_pem_x509_certificate(cert_pem)
+            self.key = serialization.load_pem_private_key(cert_pem, password=None)
+        except Exception as e:
+            raise DaneBotError(f"loading --cert-file: {e}")
         # TODO: Check if key belongs to cert
         self.cert_sha256 = self.cert.fingerprint(hashes.SHA256())
         self.dane_ee_hash = get_dane_ee_hash(self.cert)


### PR DESCRIPTION
Some example error messages:

File doesn't exist:
```
Error: loading --cert-file: [Errno 2] No such file or directory: '/etc/lego/.lego/certificates/example.com.pem'
```

File doesn't contain a certificate:
```
Error: loading --cert-file: Unable to load certificate. See https://cryptography.io/en/latest/faq.html#why-can-t-i-import-my-pem-file for more details.
```

File doesn't contain a key:
```
Error: loading --cert-file: Could not deserialize key data. The data may be in an incorrect format or it may be encrypted with an unsupported algorithm.
```